### PR TITLE
The max stable pages set to 32 gb

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -13,9 +13,10 @@
     },
     "defaults": {
         "build": {
-            "packtool": "mops sources",
-            "args": ""
+          "_args_comment": "--max-stable-pages=524288 -> 32 GB  [524288 = 32 GB / 64Kb(each page size) ] -> (524288 * 65536) = 34359738368 bytes = 33554432 kb = 32768 MB = 32 GB",
+          "args": "--max-stable-pages=524288", 
+          "packtool": "mops sources"
         }
-    }
+      }
     
 }


### PR DESCRIPTION
The max stable pages size is set to 32 gb in dfx.json file